### PR TITLE
Your terms of service are really bad

### DIFF
--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -54,13 +54,12 @@
 <div class="section">
 <h1 class="section-head">Terms Of Service</h1>
 <p>Our developers, designers and helpers have spent countless hours working extremely hard to get DragonDrop to its current state. To make sure that their hard work is used correctly and used how it should be, there are some terms that you must abide by. Failing to do so may result in your account being terminated. So we suggest reading this and acknoledging the following article.</p>
-<h3>Availability</h3>
-<p>i) Once published your website can be viewed and accessed by everyone who has access to the internet with a browser. You must make it appropriate for all ages, or you site and account will be taken down.</p>
-<h3>Source Code</h3>
-<p>i) We do like it when people make use of our source code, however you must credit the whole development team who had created DragonDrop if you are unsure of the certain developer that coded that section.</p>
-<p>ii) We consider taking more than just a few lines of code is called stealing. In the unlikely case that this happens often, the source code will be private only to the development team.</p>
-<h3>Copyright</h3>
-<p>&nbsp;i) Scratch is developed by the Lifelong Kindergarten Group at the MIT Media Lab, and although Dragon Drop was created with Scratch users in mind it is not in anyway officaly owned by MIT or The Scratch Team. See http://scratch.mit.edu</p>
-<p>&nbsp;</p>
+<h3>1. Availability</h3>
+<p>i) Once published, your website can be viewed and accessed by everyone who has access to the internet with a browser. You must make it appropriate for all ages, and if we believe your isn't then your site and account may be taken down without any prior notice. We do not own your content, and so when you use our services, your content stays yours.</p>
+<h3>2. Source Code</h3>
+<p>i) When using a substantial portion of source code created by DragonDrop you must provide appropriate credit to either the entire DragonDrop Team or the people that contributed to the section of source code you are using.</p>
+<p>ii) We think more than a few lines of code is a substantial portion of source code. If people repeatedly violate section 2i of these terms, the DragonDrop may become closed source..</p>
+<h3>3. Copyright</h3>
+<p> i) <em>DragonDrop is not in anyway owned by or affiliated with MIT, Scratch or The Scratch Team</em>. DragonDrop was intended to be used mostly by Scratch users. See http://scratch.mit.edu</p>
 </div>
 </div>


### PR DESCRIPTION
No offense to who wrote them, but  `the source code will be private only to the development team.` is really ambiguous: you wanted to say that the team _will_ have access to the source, but you wrote it in such a way that it will be public for everybody else. Your lack of definitions (which I did not add) means that there is so much ambiguity. I've made a few changes, but it isn't enough. Also, you should add a footnote to every page that links to the ToSs.
