### PR TITLE
Fixed #typed box overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,10 +126,8 @@
                 color: lime;
                 font-family:"Courier";
                 font-size: 20px;
-                margin: 10px 0 0 10px;
-                white-space: nowrap;
+                margin: 10px 10px 10px 10px;
                 overflow: hidden;
-                width: 50em;
                 animation: type 4s steps(132, end);
                 animation-delay: 2s;
             }
@@ -319,8 +317,10 @@
             </div>
             <div class="section">
                 <div class="typeddiv">
-                     <h1 id="typed">No programming or development knowledge
-                needed. Just start making your free <br> website today, and have it done in minutes!<span>|</span></h1>
+                    <h1 id="typed">No programming or development knowledge needed.
+                        Just start making your free website today, and have it done in minutes!
+                        <span>|</span>
+                    </h1>
                     <br>
                     <br>
                     <br>


### PR DESCRIPTION
This box wasn't well made:
- there were a "width" but it is an inline object
- the new line was made using a br but it should have been done using the regular content wrapping
- there were an useless white-spaces
- there is a fishy pipe character at line 322, check if you really need it
